### PR TITLE
filter out graviton gateways

### DIFF
--- a/components/Swaps.vue
+++ b/components/Swaps.vue
@@ -55,7 +55,7 @@ import TableAvatarIcon from "~/components/TableAvatarIcon.vue";
 import { Swap } from "~/models/model/transaction";
 import {
  TransactionDataProvider,
- GetNebula
+ GetSusyNebula
 } from "~/data/providers/transaction";
 import { FetchCommand } from "~/data/global";
 import { TimestampFormatter } from "~/misc/format";
@@ -77,11 +77,11 @@ export default Vue.extend({
   };
  },
  // eslint-disable-next-line vue/require-prop-types
- computed: {
-  mappedSwapsList() {
-   return this.swapsList as Swap[];
-  }
- },
+     // computed: {
+     //  mappedSwapsList() {
+     //   return this.swapsList as Swap[];
+     //  }
+     // },
  methods: {
   queryUpdate(query: string) {
    // @ts-ignore
@@ -104,14 +104,14 @@ export default Vue.extend({
    return TimestampFormatter.format(timestamp);
   },
   formatAmount(nebula_id: string, amount: number) {
-   var nebula = GetNebula(nebula_id);
+   var nebula = GetSusyNebula(nebula_id);
    if (!nebula) {
     return amount;
    }
    return nebula.formatAmount(amount);
   },
   getDirection(nebula_id: string) {
-   var nebula = GetNebula(nebula_id);
+   var nebula = GetSusyNebula(nebula_id);
    if (!nebula) {
     return "undefined";
    }

--- a/data/providers/transaction.ts
+++ b/data/providers/transaction.ts
@@ -68,7 +68,7 @@ class Nebula {
   }
 }
 
-const availableNebulae: Array<Nebula> = [
+const susyNebulae: Array<Nebula> = [
   new Nebula(
     "0x3a9e63494d6258feeaa2a348c519cc14c6df8827",
     "0x8c0e11a6E692d02f71598AB5050083ED691Eb760",
@@ -176,8 +176,20 @@ const availableNebulae: Array<Nebula> = [
   ),
 ];
 
-export function GetNebula(nebula_id: string) {
-  return availableNebulae.find((nebula) => nebula.nebula_id.toLowerCase() == nebula_id.toLowerCase());
+const gravitonNebulae: Array<Nebula> = [
+  new Nebula(
+    "0x3efb36001cc91204241ba4638c3c32af4cd560c7",
+    "",
+    "",
+    "",
+    0
+  ),
+]
+export function GetSusyNebula(nebula_id: string) {
+  return susyNebulae.find((nebula) => nebula.nebula_id.toLowerCase() == nebula_id.toLowerCase());
+}
+export function IsGravitonNebula(nebula_id: string) {
+  return gravitonNebulae.some((nebula) => nebula.nebula_id.toLowerCase() == nebula_id.toLowerCase());
 }
 
 export class TransactionDataProvider {
@@ -266,6 +278,8 @@ export class TransactionDataProvider {
     });
     if (!resp.data) return [];
 
-    return resp.data;
+    var list: Swap[] = resp.data
+    list = list.filter((swap) => !IsGravitonNebula(swap.nebula_id))
+    return list;
   }
 }

--- a/pages/swaps/index.vue
+++ b/pages/swaps/index.vue
@@ -12,7 +12,7 @@ import Vue from 'vue'
 import { Subject as PublishSubject, BehaviorSubject, Subscription } from 'rxjs'
 import { debounceTime, filter } from 'rxjs/operators'
 import Swaps from '~/components/Swaps.vue'
-import { TransactionDataProvider } from '~/data/providers/transaction'
+import { TransactionDataProvider, IsGravitonNebula } from '~/data/providers/transaction'
 import { Swap } from '~/models/model/transaction'
 import { FetchCommand } from '~/data/global'
 
@@ -38,7 +38,7 @@ export default Vue.extend({
     const paginationSub = this.command
       .pipe(
         filter(
-          (command) => command.page !== undefined && command.page !== 1 && this.swapsList.length > 15
+          (command) => command.page !== undefined && command.page !== 1 // && this.swapsList.length > 15
         )
       )
       .subscribe((command) => {
@@ -78,8 +78,8 @@ export default Vue.extend({
     },
     concatData(command: FetchCommand) {
       TransactionDataProvider.fetchAllSwaps(command).then((list) => {
-        // @ts-ignore
-        this.swapsSubject.next([...this.swapsList, ...list])
+          // @ts-ignore
+          this.swapsSubject.next([...this.swapsList, ...list])
       })
     },
     queryUpdate(command: FetchCommand) {


### PR DESCRIPTION
Remove graviton reveal transactions from the list of swaps until new attachData format settles in and the backend can decode them properly. 
Without this PR transactions from graviton nebulas will will show up as garbage in the list of swaps.